### PR TITLE
[fix]VOLUME_IDS の変数を配列に修正

### DIFF
--- a/02.ec2/ec2.sh
+++ b/02.ec2/ec2.sh
@@ -35,14 +35,14 @@ NETWORK_INTERFACE_ID=$(aws ec2 describe-instances \
   --query "Reservations[*].Instances[*].NetworkInterfaces[*].NetworkInterfaceId" \
   --output text) && echo $NETWORK_INTERFACE_ID
 
-VOLUME_IDS=$(aws ec2 describe-instances \
+## 2024/10/20 VOLUME_IDS の変数を配列に修正
+VOLUME_IDS=($(aws ec2 describe-instances \
   --instance-id $INSTANCE_ID \
   --query "Reservations[*].Instances[*].BlockDeviceMappings[*].Ebs.VolumeId" \
-  --output text) && echo $VOLUME_IDS
+  --output text)) && echo "${VOLUME_IDS[@]}"
 
-aws ec2 create-tags --resources $NETWORK_INTERFACE_ID $VOLUME_IDS --tags Key=Name,Value=$EC2_NAME
+aws ec2 create-tags --resources "$NETWORK_INTERFACE_ID" "${VOLUME_IDS[@]}" --tags Key=Name,Value=$EC2_NAME
 
 # Check HTTP connection
 PUBLIC_IP_ADDRESS=$(aws ec2 describe-instances --instance-id $INSTANCE_ID --query "Reservations[*].Instances[*].PublicIpAddress" --output text) && echo $PUBLIC_IP_ADDRESS
 curl http://$PUBLIC_IP_ADDRESS
-


### PR DESCRIPTION
## 現象

create-tags コマンドを使用して作成した EC2 にタグを付与する時、VOLUME_ID の変数が認識されずエラーになる
```
% VOLUME_IDS=$(aws ec2 describe-instances \
  --instance-id $INSTANCE_ID \
  --query "Reservations[*].Instances[*].BlockDeviceMappings[*].Ebs.VolumeId" \
  --output text) && echo $VOLUME_IDS
vol-09369b8754f6a8773   vol-0b516753be8d0ee29

% aws ec2 create-tags --resources $NETWORK_INTERFACE_ID $VOLUME_IDS --tags Key=Name,Value=$EC2_NAME

An error occurred (InvalidID) when calling the CreateTags operation: The ID 'vol-09369b8754f6a8773      vol-0b516753be8d0ee29' is not valid
```

Windows WSL2環境 (Ubuntu) では発生しないが、macOSでは再現性あり。
以下の環境で検証

- M1 Macbook Air
- Sonoma 14.6.1
- aws-cli/2.17.13 Python/3.11.9 Darwin/23.6.0 exe/x86_64

--output json の結果は次のとおり。
```
aws ec2 describe-instances \
  --instance-id $INSTANCE_ID \
  --query "Reservations[*].Instances[*].BlockDeviceMappings[*].Ebs.VolumeId" --output json
[
    [
        [
            "vol-09369b8754f6a8773",
            "vol-0b516753be8d0ee29"
        ]
    ]
]
```

## 原因

`--resources` で渡している $VOLUME_IDS が 'vol-09369b8754f6a8773      vol-0b516753be8d0ee29' という一つの文字列として認識されているため。

## 対処方法

$VOLUME_IDS を配列として格納し `${array[@]}` の形式で配列を参照するように修正
```
VOLUME_IDS=($(aws ec2 describe-instances \
  --instance-id $INSTANCE_ID \
  --query "Reservations[*].Instances[*].BlockDeviceMappings[*].Ebs.VolumeId" \
  --output text)) && echo "${VOLUME_IDS[@]}"

aws ec2 create-tags --resources "$NETWORK_INTERFACE_ID" "${VOLUME_IDS[@]}" --tags Key=Name,Value=$EC2_NAME
```